### PR TITLE
use shouldNotTypecheck

### DIFF
--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,6 +6,7 @@
 
 module Main where
 
+import Data.ByteString
 import Data.List.NonEmpty
 import Data.Text (Text)
 import Test.Hspec
@@ -73,4 +74,8 @@ spec = do
       let tuple = (1 :: Int, True, "hahahha" :: String)
       T.unpack (display tuple) `shouldBe` show tuple
     it "Should not compile for a function instance" $
-      (shouldNotTypecheck $ display id) `shouldThrow` anyErrorCall
+      shouldNotTypecheck (display id) `shouldThrow` anyErrorCall
+    it "Should not compile for ByteStrings" $
+      let bs = "badstring" :: ByteString
+       in shouldNotTypecheck (display bs) `shouldThrow` anyErrorCall
+

--- a/text-display.cabal
+++ b/text-display.cabal
@@ -54,6 +54,7 @@ test-suite text-display-test
   hs-source-dirs: test
   build-depends:
     , base
+    , bytestring
     , text-display
     , hspec
     , text


### PR DESCRIPTION
Uses the nice library [shouldNotTypecheck](https://github.com/CRogers/should-not-typecheck) to test the function instance and the ByteString instance.

Note that it needed the `shouldThrow` as well, because otherwise the `undefined` bubbles up.

For functions, I changed it to `id` so it doesn't give a warning about defaulting the `+` instance.

And note, naturally, because of deferred type errors, the errors do get printed out when compiling the tests; but the tests pass.

-- Edit: Fyi, it would help if there was a reproducible way of building this project; I opted to configure a stack project (I'm not sure what the intended way was; I notice there's a nix setup, but only for CI, and a Makefile, but that assumes `cabal` on the path), but that meant I didn't easily get hlint, etc :)