### PR TITLE
feat: displayBuilder and displayBuilderList

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,25 @@ display $ UserToken "7a01d2ce-31ff-11ec-8c10-5405db82c3cd"
 -- => "[REDACTED]"                                              
 ```
 
+Since `append` from `Data.Text` is `O(n)`, for efficiency you may implement
+`displayBuilder` which encodes to `text`'s `Builder` type, which has an `O(1)`
+`append`. This is especially useful for types that are defined recursively,
+like lists or trees for example. Since `Builder` is a buffer used for efficiently
+building `Text` values, it's primarily used for defining instances of `Display`, but
+`display` and `displayBuilder` may be used interchangeably to the user's discretion.
+
+```haskell
+data Tree a = Node a [Tree a]
+
+instance Display a => Display (Tree a) where
+  -- displayBuilder for the instance
+  displayBuilder (Node a xs) = displayBuilder a <> displayBuilderList xs
+
+-- display for the application code
+display $ Node 1 [Node 2 [], Node 3 [], Node 4 []]
+-- => "1[2[],3[],4[]]"
+```
+
 ## Design Choices
 
 ### A “Lawless Typeclass”[^1]

--- a/src/Data/Text/Display.hs
+++ b/src/Data/Text/Display.hs
@@ -195,19 +195,23 @@ newtype ShowInstance (a :: Type)
 instance Show e => Display (ShowInstance e) where
   display s = T.pack $ show s
 
+-- @since 0.0.1.0
 newtype DisplayDecimal e
   = DisplayDecimal e
   deriving newtype
     (Integral, Real, Enum, Ord, Num, Eq)
 
+-- @since 0.0.1.0
 instance Integral e => Display (DisplayDecimal e) where
   displayBuilder = TB.decimal
 
+-- @since 0.0.1.0
 newtype DisplayRealFloat e 
   = DisplayRealFloat e
   deriving newtype
     (RealFloat, RealFrac, Real, Ord, Eq, Num, Fractional, Floating)
 
+-- @since 0.0.1.0
 instance RealFloat e => Display (DisplayRealFloat e) where
   displayBuilder = TB.realFloat
 
@@ -219,11 +223,11 @@ deriving via (ShowInstance Bool) instance Display Bool
 
 -- | @since 0.0.1.0
 instance Display Char where
-  display '\'' = "'\\''"
-  display c = "'" <> T.singleton c <> "\'"
+  displayBuilder '\'' = "'\\''"
+  displayBuilder c = "'" <> TB.singleton c <> "\'"
   -- 'displayList' is overloaded, so that when the @Display [a]@ instance calls 'displayList',
   -- we end up with a nice string enclosed between double quotes.
-  displayList cs = T.pack $ "\"" <> showLitString cs "\""
+  displayBuilderList cs = TB.fromString $ "\"" <> showLitString cs "\""
 
 -- | Lazy 'TL.Text'
 --


### PR DESCRIPTION
the idea is that users can define more efficient `Display` instances using the `Builder` type from https://hackage.haskell.org/package/text-1.2.5.0/docs/Data-Text-Lazy-Builder.html

I am not married to the names I picked or the documentation, so lmk if there's improvements you would make