### PR TITLE
Update the CI to add GHC 9.2 and Cabal 3.6 to the matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Configure Darwin Nixpkgs
       if: matrix.os == 'macos-latest' 
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-21.05-darwin"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:unstable-darwin"' >> "$GITHUB_ENV"
 
     - name: Configure Linux Nixpkgs
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:nixos-21.05"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:unstable"' >> "$GITHUB_ENV"
 
     - name: Set GHC version for Nix
       run: |
@@ -50,6 +50,8 @@ jobs:
         then echo "GHC='8104'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"
+        elif [[ ${{matrix.ghc}} == '9.0.1' ]]
+        then echo "GHC='921'" >> "$GITHUB_ENV"
         fi
 
     - name: Install Nix

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         then echo "GHC='8104'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"
-        elif [[ ${{matrix.ghc}} == '9.0.1' ]]
+        elif [[ ${{matrix.ghc}} == '9.2.1' ]]
         then echo "GHC='921'" >> "$GITHUB_ENV"
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,12 +35,12 @@ jobs:
     - name: Configure Darwin Nixpkgs
       if: matrix.os == 'macos-latest' 
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:unstable-darwin"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-unstable-darwin"' >> "$GITHUB_ENV"
 
     - name: Configure Linux Nixpkgs
       if: matrix.os == 'ubuntu-latest'
       run: |
-        echo 'NIX_PATH="nixpkgs=channel:unstable"' >> "$GITHUB_ENV"
+        echo 'NIX_PATH="nixpkgs=channel:nixpkgs-unstable"' >> "$GITHUB_ENV"
 
     - name: Set GHC version for Nix
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         cabal: ["3.4.0.0", "3.6.2.0"]
-        ghc: ["8.8.4", "8.10.4", "9.0.1", "9.2.1"]
+        ghc: ["8.8.4", "8.10.7", "9.0.1", "9.2.1"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   cabal:
-    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }} (${{ matrix.cabal }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        cabal: ["3.4.0.0"]
-        ghc: ["8.8.4", "8.10.4", "9.0.1"]
+        cabal: ["3.4.0.0", "3.6.2.0"]
+        ghc: ["8.8.4", "8.10.4", "9.0.1", "9.2.1"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
       run: |
         if [[ ${{matrix.ghc}} == '8.8.4' ]]
         then echo "GHC='884'" >> "$GITHUB_ENV"
-        elif [[ ${{matrix.ghc}} == '8.10.4' ]]
-        then echo "GHC='8104'" >> "$GITHUB_ENV"
+        elif [[ ${{matrix.ghc}} == '8.10.7' ]]
+        then echo "GHC='8107'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.0.1' ]]
         then echo "GHC='901'" >> "$GITHUB_ENV"
         elif [[ ${{matrix.ghc}} == '9.2.1' ]]

--- a/.github/workflows/shell.nix
+++ b/.github/workflows/shell.nix
@@ -9,8 +9,6 @@ in with pkgs;
       hlint
       haskellPackages.apply-refact
 
-      # DB Deps
-      postgresql_13
       gmp
       zlib
       glibcLocales


### PR DESCRIPTION
* [ ] GHC 9.2.1 needs to be in nixpkgs-unstable

