### PR TITLE
Cache HLint build properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           path: ./text-display
       - name: Run HLint
-        run: find text-display/src text-display/test -name "*.hs" -exec ${{ steps.setup-haskell.outputs.cabal-store }}/../bin/hlint {} + 
+        run: |
+          cd text-display && find src test -name "*.hs" -exec ${{ steps.setup-haskell.outputs.cabal-store }}/../bin/hlint {} + 
   native:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,23 +11,33 @@ jobs:
     name: HLint
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base repo
+      - name: Checkout HLint repo
         uses: actions/checkout@v2
+        with:
+          repository: ndmitchell/hlint
       - name: Set up Haskell
         id: setup-haskell
         uses: haskell/actions/setup@v1
         with:
           ghc-version: '9.0.1'
           cabal-version: 'latest'
+      - name: Configure HLint
+        run: cabal new-configure
+      - name: Freeze HLint
+        run: cabal freeze
       - name: Cache
         uses: actions/cache@v2.1.3
         with:
           path: ${{ steps.setup-haskell.outputs.cabal-store }}
-          key: 'hlint-334'
+          key: ${{ hashFiles('cabal.project.freeze') }}
       - name: Build HLint
-        run: cd .. && cabal new-install hlint-3.3.4
+        run: cabal new-install
+      - name: Checkout text-display
+        uses: actions/checkout@v2
+        with:
+          path: ./text-display
       - name: Run HLint
-        run: find src test -name "*.hs" -exec ${{ steps.setup-haskell.outputs.cabal-store }}/../bin/hlint {} + 
+        run: find text-display/src text-display/test -name "*.hs" -exec ${{ steps.setup-haskell.outputs.cabal-store }}/../bin/hlint {} + 
   native:
     name: ${{ matrix.ghc }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: ndmitchell/hlint
+          ref: '8e10b5143acf97fbdf9baff40ee2da93881e0bf8'
       - name: Set up Haskell
         id: setup-haskell
         uses: haskell/actions/setup@v1


### PR DESCRIPTION
This resolves an issue where the HLint build caching would be brittle against new versions of packages that HLint depends on, but does not strictly bound.