### PR TITLE
Add GHC 9.2 and Windows to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ghc: ['8.8.4', '8.10.7', '9.0.1', '9.2.1']
-        exclude:
-          - os: windows-latest
-            ghc: '9.2.1'
+        ghc: ['8.8', '8.10', '9.0', '9.2.1']
     steps:
       - name: Checkout base repo
         uses: actions/checkout@v2


### PR DESCRIPTION
Now that there's a Chocolatey package for 9.2, we can test on it as well.