### PR TITLE
Allow bytestring 0.12 (for GHC 9.8)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           ghcup config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml
       - name: Set up Haskell
         id: setup-haskell
-        uses: haskell/actions/setup@v2
+        uses: haskell-actions/setup@v2
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: 'latest'

--- a/text-display.cabal
+++ b/text-display.cabal
@@ -15,7 +15,7 @@ maintainer:         Hécate Moonlight
 license:            MIT
 build-type:         Simple
 tested-with:
-  GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.2
+  GHC ==8.8.4 || ==8.10.7 || ==9.0.2 || ==9.2.8 || ==9.4.7 || ==9.6.3 || ==9.8.1
 
 extra-source-files:
   LICENSE
@@ -67,7 +67,7 @@ library
     Data.Text.Display.Generic
   build-depends:
     , base        >=4.12 && <5.0
-    , bytestring  >=0.10 && <0.12
+    , bytestring  >=0.10 && <0.13
     , text        >=2.0
 
 executable book


### PR DESCRIPTION
Support bytestring 0.12, which is shipped with GHC 9.8, and hence might be non-reinstallable.

Also adds GHC 9.8 to CI

## Submitter checklist

- [x] I have read and understood the [CONTRIBUTING guide](https://github.com/Kleidukos/text-display/blob/main/CONTRIBUTING.md)

